### PR TITLE
[LINK-14000] UI cropping issue on sample app

### DIFF
--- a/runa.sample/app/src/main/java/com/runa/sample/RecyclerViewActivity.kt
+++ b/runa.sample/app/src/main/java/com/runa/sample/RecyclerViewActivity.kt
@@ -22,7 +22,7 @@ import com.squareup.picasso.Picasso
 
 internal class RecyclerViewActivity : AppCompatActivity() {
 
-    private val ADSPOT_IDS = arrayOf("", "", "")
+    private val ADSPOT_IDS = arrayOf("1502", "1601", "1602")
     private val INTERVAL = 10
 
     private val binding: ActivityMultipleBannerRecyclerviewBinding by lazy {


### PR DESCRIPTION
Steps to Reproduce the issue:
> Updated ADSPOT_IDS  ("1502", "1601", "1602") in RecyclerViewActivity.kt
> Launch the application and select "ADS IN THE LIST" option.
> Please observe the UI for the ADSPOT_ID "1502".

Note: After increasing the display/font size from the device setting then also add is getting cropped.

<img width="371" alt="Screenshot 2022-03-09 at 12 42 14 PM" src="https://user-images.githubusercontent.com/78465017/157426367-68a55602-1c0d-43ce-af1f-a3cd920da369.png">


